### PR TITLE
Configurada integración de Spring en WicketApplication

### DIFF
--- a/src/main/java/ar/edu/unq/sarmiento/wicket/home/WicketApplication.java
+++ b/src/main/java/ar/edu/unq/sarmiento/wicket/home/WicketApplication.java
@@ -2,6 +2,7 @@ package ar.edu.unq.sarmiento.wicket.home;
 
 import org.apache.wicket.Page;
 import org.apache.wicket.protocol.http.WebApplication;
+import org.apache.wicket.spring.injection.annot.SpringComponentInjector;
 
 import ar.edu.unq.sarmiento.hibernate.HibernateConf;
 
@@ -12,5 +13,10 @@ public class WicketApplication extends WebApplication{
 		HibernateConf.modo = "server";
 		return HomePage.class;
 	}
-
+	
+	@Override
+	protected void init() {
+		super.init();
+	    getComponentInstantiationListeners().add(new SpringComponentInjector(this));
+	}
 }


### PR DESCRIPTION
En [este artículo](https://www.mkyong.com/wicket/wicket-spring-integration-example/) descubrí que faltaba esto y en [esta pregunta de StackOverflow](https://stackoverflow.com/questions/8155359/how-can-i-get-a-spring-bean-injected-in-my-custom-wicket-model-class) explica cómo hacerlo para Wicket > 1.5 (estamos usando el 8).