### PR TITLE
Selector de campos booleanos

### DIFF
--- a/src/main/java/ar/edu/unq/sarmiento/wicket/materia/AgregarMateriaController.java
+++ b/src/main/java/ar/edu/unq/sarmiento/wicket/materia/AgregarMateriaController.java
@@ -27,7 +27,7 @@ public class AgregarMateriaController implements Serializable {
 	private Materia materia;
 	private Carrera carrera;
 	private String nombre;
-	private boolean promocionable;
+	private boolean promocionable = false;
 	private int anioEnCarrera;
 	private String docente;
 

--- a/src/main/java/ar/edu/unq/sarmiento/wicket/materia/AgregarMateriaPage.html
+++ b/src/main/java/ar/edu/unq/sarmiento/wicket/materia/AgregarMateriaPage.html
@@ -15,9 +15,8 @@
 				<div class="form-group">
 					<label for="promocion" class="col-md-2 control-label">Es
 						promocionable </label>
-					<div class="col-md-9">
-						<input type="text" class="form-control" id="promocion"
-							wicket:id="promocion" placeholder="si/no">
+					<div class="col-md-1">
+						<select id="promocion" class="form-control" wicket:id="promocion"></select>
 					</div>
 				</div>
 

--- a/src/main/java/ar/edu/unq/sarmiento/wicket/materia/AgregarMateriaPage.html
+++ b/src/main/java/ar/edu/unq/sarmiento/wicket/materia/AgregarMateriaPage.html
@@ -15,7 +15,7 @@
 				<div class="form-group">
 					<label for="promocion" class="col-md-2 control-label">Es
 						promocionable </label>
-					<div class="col-md-1">
+					<div class="col-md-2">
 						<select id="promocion" class="form-control" wicket:id="promocion"></select>
 					</div>
 				</div>
@@ -23,7 +23,7 @@
 
 				<div class="form-group">
 					<label for="anio" class="col-md-2 control-label">Año </label>
-					<div class="col-md-1">
+					<div class="col-md-2">
 						<select id="anio" class="form-control" wicket:id="anio"></select>
 					</div>
 				</div>

--- a/src/main/java/ar/edu/unq/sarmiento/wicket/materia/AgregarMateriaPage.java
+++ b/src/main/java/ar/edu/unq/sarmiento/wicket/materia/AgregarMateriaPage.java
@@ -1,6 +1,7 @@
 package ar.edu.unq.sarmiento.wicket.materia;
 
-import org.apache.wicket.markup.html.form.ChoiceRenderer;
+import java.util.Arrays;
+
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.TextField;
@@ -9,6 +10,7 @@ import org.apache.wicket.spring.injection.annot.SpringBean;
 
 import ar.edu.unq.sarmiento.modelo.Carrera;
 import ar.edu.unq.sarmiento.wicket.layout.LayoutPage;
+import ar.edu.unq.sarmiento.wicket.utils.BooleanToSiNoRenderer;
 
 public class AgregarMateriaPage extends LayoutPage {
 	/**
@@ -41,8 +43,9 @@ public class AgregarMateriaPage extends LayoutPage {
 		};
 
 		altaMateria.add(new TextField<>("nombre", new PropertyModel<>(agregarMateriasController, "nombre")));
-		altaMateria
-				.add(new TextField<>("promocion", new PropertyModel<>(agregarMateriasController, "isPromocionable")));
+		altaMateria.add(
+				new DropDownChoice<>("promocion", new PropertyModel<>(agregarMateriasController, "promocionable"), 
+						BooleanToSiNoRenderer.opciones(), new BooleanToSiNoRenderer()));
 		altaMateria.add(new TextField<>("docente", new PropertyModel<>(agregarMateriasController, "docente")));
 
 		altaMateria
@@ -51,5 +54,4 @@ public class AgregarMateriaPage extends LayoutPage {
 
 		this.add(altaMateria);
 	};
-
 }

--- a/src/main/java/ar/edu/unq/sarmiento/wicket/materia/AgregarMateriaPage.java
+++ b/src/main/java/ar/edu/unq/sarmiento/wicket/materia/AgregarMateriaPage.java
@@ -11,6 +11,7 @@ import org.apache.wicket.spring.injection.annot.SpringBean;
 import ar.edu.unq.sarmiento.modelo.Carrera;
 import ar.edu.unq.sarmiento.wicket.layout.LayoutPage;
 import ar.edu.unq.sarmiento.wicket.utils.BooleanToSiNoRenderer;
+import ar.edu.unq.sarmiento.wicket.utils.SiNoDropDownChoice;
 
 public class AgregarMateriaPage extends LayoutPage {
 	/**
@@ -43,9 +44,7 @@ public class AgregarMateriaPage extends LayoutPage {
 		};
 
 		altaMateria.add(new TextField<>("nombre", new PropertyModel<>(agregarMateriasController, "nombre")));
-		altaMateria.add(
-				new DropDownChoice<>("promocion", new PropertyModel<>(agregarMateriasController, "promocionable"), 
-						BooleanToSiNoRenderer.opciones(), new BooleanToSiNoRenderer()));
+		altaMateria.add(new SiNoDropDownChoice("promocion", new PropertyModel<>(agregarMateriasController, "promocionable")));
 		altaMateria.add(new TextField<>("docente", new PropertyModel<>(agregarMateriasController, "docente")));
 
 		altaMateria

--- a/src/main/java/ar/edu/unq/sarmiento/wicket/utils/BooleanToSiNoRenderer.java
+++ b/src/main/java/ar/edu/unq/sarmiento/wicket/utils/BooleanToSiNoRenderer.java
@@ -1,0 +1,30 @@
+package ar.edu.unq.sarmiento.wicket.utils;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.wicket.markup.html.form.IChoiceRenderer;
+import org.apache.wicket.model.IModel;
+
+public class BooleanToSiNoRenderer implements IChoiceRenderer<Boolean> {
+	private static final long serialVersionUID = 7602762203807447870L;
+
+	@Override
+	public Object getDisplayValue(Boolean object) {
+		return object ? "Sí" : "No";
+	}
+
+	@Override
+	public String getIdValue(Boolean object, int index) {
+		return object.toString();
+	}
+
+	@Override
+	public Boolean getObject(String id, IModel<? extends List<? extends Boolean>> choices) {
+		return Boolean.valueOf(id);
+	}
+
+	public static List<Boolean> opciones() {
+		return Arrays.asList(false, true);
+	}
+}

--- a/src/main/java/ar/edu/unq/sarmiento/wicket/utils/BooleanToSiNoRenderer.java
+++ b/src/main/java/ar/edu/unq/sarmiento/wicket/utils/BooleanToSiNoRenderer.java
@@ -1,6 +1,5 @@
 package ar.edu.unq.sarmiento.wicket.utils;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.apache.wicket.markup.html.form.IChoiceRenderer;
@@ -22,9 +21,5 @@ public class BooleanToSiNoRenderer implements IChoiceRenderer<Boolean> {
 	@Override
 	public Boolean getObject(String id, IModel<? extends List<? extends Boolean>> choices) {
 		return Boolean.valueOf(id);
-	}
-
-	public static List<Boolean> opciones() {
-		return Arrays.asList(false, true);
 	}
 }

--- a/src/main/java/ar/edu/unq/sarmiento/wicket/utils/SiNoDropDownChoice.java
+++ b/src/main/java/ar/edu/unq/sarmiento/wicket/utils/SiNoDropDownChoice.java
@@ -7,9 +7,6 @@ import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.model.IModel;
 
 public class SiNoDropDownChoice extends DropDownChoice<Boolean> {
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = -9165991864318804365L;
 	
 	public SiNoDropDownChoice(String id, IModel<Boolean> model) {

--- a/src/main/java/ar/edu/unq/sarmiento/wicket/utils/SiNoDropDownChoice.java
+++ b/src/main/java/ar/edu/unq/sarmiento/wicket/utils/SiNoDropDownChoice.java
@@ -1,0 +1,22 @@
+package ar.edu.unq.sarmiento.wicket.utils;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.wicket.markup.html.form.DropDownChoice;
+import org.apache.wicket.model.IModel;
+
+public class SiNoDropDownChoice extends DropDownChoice<Boolean> {
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = -9165991864318804365L;
+	
+	public SiNoDropDownChoice(String id, IModel<Boolean> model) {
+		super(id, model, opciones(), new BooleanToSiNoRenderer());
+	}
+
+	private static List<Boolean> opciones() {
+		return Arrays.asList(false, true);
+	}
+}


### PR DESCRIPTION
Closes #120 

Básicamente lo que hice fue crear dos clases:

* `BooleanToSiNoRenderer`, sirve para que el dropdown muestre los booleanos como queremos. Para implementar un `ChoiceRenderer` hay que armar 3 métodos: uno que indica cómo mostrar el objeto en el dropdown, otro que indica cuál es el "id" del objeto y otro que le dice a Wicket cómo encontrar el objeto en la lista a partir del id. 
* `SiNoDropDownChoice`, que lo hice para ahorrar algunos pasos en la construcción del dropdown. Siempre que tengamos un dropdown de Sí o No, las opciones van a ser las mismas y queremos que se vean de la misma manera... eso hace esta clase.

Así quedó:
![image](https://user-images.githubusercontent.com/1585835/49981180-69e89580-ff35-11e8-9599-7b600a5f9430.png)
