### PR TITLE
Mecanismo de manejo errores

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,44 @@ En el proyecto hay una serie de clases ejecutables que ayudan en esta tarea:
 * `DumpSQLSchema.java`: exporta el esquema generado por Hibernate al archivo `src/main/resources/db/schema.sql`. Resulta útil para ver qué cambió.
 * `CreateMigrationFile.java`: crea un archivo vacío para escribir una migración, usando la convención de nombre por fecha y hora. Es importante recordar agregarle una descripción adecuada.
 * `RunFlywayDBMigrations.java`: corre las migraciones necesarias y actualiza el archivo con el schema.
+#Manejo de errores:
+
+##Instalación:
+
+ * Agregar las dependencias en el pom:
+    wicket_bean_validation:
+     
+       <dependency>
+       <groupId>org.apache.wicket</groupId>
+       <artifactId>wicket-bean-validation</artifactId>
+       <version>${wicket.version}</version>
+       </dependency> 
+
+    hibernate_validator:
+        <dependency>
+        <groupId>org.hibernate</groupId>
+        <artifactId>hibernate-validator</artifactId>
+        <version>5.3.5.Final</version>
+        </dependency>
+
+ * Agregar las clases:
+
+    Creamos la clase ModelErrorRequestCycleListernerHandler que se utiliza para poder insertar código en el momento que se hace resquest, en nuestro caso la usamos para chequear si es un 
+    error de ModelException o un defaultException(error fuera de nuestro modelo) y lanzar el error según sea el caso.
+
+    Creamos la clase ModelException que se utiliza para filtrar los errores que se generan en nuestro modelo. 
+
+    Creamos la clase BootstrapFeedbackPanel y su respectivo html en donde en la clase se definirá su construcción y sus diferentes ventanas del panel. En el html su construcción para 
+    visualizar en el navegador. Se agrega al archivo main.css el estilo del feedbackPanel.
+    
+ * Configuración en Wicket:
+    
+    En WicketAplication se utilizan para:
+       validación imperativa: - PageRequestHandlerTracker.
+                              - ModelErrorRequestCycleListernerHandler
+
+       annotations: - BeanValidationConfiguration.
+
+ * Configuración de la clase LayoutPage a la cual agregamos el componente BootstrapFeedbackPanel y en su correspondiente html definimos la construcción para visualizar en el navegador.
+ 
+

--- a/README.md
+++ b/README.md
@@ -76,11 +76,13 @@ En el proyecto hay una serie de clases ejecutables que ayudan en esta tarea:
 * `DumpSQLSchema.java`: exporta el esquema generado por Hibernate al archivo `src/main/resources/db/schema.sql`. Resulta útil para ver qué cambió.
 * `CreateMigrationFile.java`: crea un archivo vacío para escribir una migración, usando la convención de nombre por fecha y hora. Es importante recordar agregarle una descripción adecuada.
 * `RunFlywayDBMigrations.java`: corre las migraciones necesarias y actualiza el archivo con el schema.
-#Manejo de errores:
 
-##Instalación:
+# Manejo de errores:
+
+## Instalación:
 
  * Agregar las dependencias en el pom:
+
     wicket_bean_validation:
      
        <dependency>
@@ -90,6 +92,7 @@ En el proyecto hay una serie de clases ejecutables que ayudan en esta tarea:
        </dependency> 
 
     hibernate_validator:
+
         <dependency>
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-validator</artifactId>
@@ -109,6 +112,7 @@ En el proyecto hay una serie de clases ejecutables que ayudan en esta tarea:
  * Configuración en Wicket:
     
     En WicketAplication se utilizan para:
+
        validación imperativa: - PageRequestHandlerTracker.
                               - ModelErrorRequestCycleListernerHandler
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,11 @@
 			<artifactId>wicket-extensions</artifactId> 
 			<version>${wicket.version}</version> 
 		</dependency>
+		<dependency>
+		    <groupId>org.apache.wicket</groupId>
+		    <artifactId>wicket-bean-validation</artifactId>
+			<version>${wicket.version}</version>
+		</dependency>
 		<!-- Integrate Wicket with Spring -->
 		<dependency>
 			<groupId>org.apache.wicket</groupId>
@@ -139,6 +144,11 @@
 		<dependency>
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-core</artifactId>
+			<version>5.3.5.Final</version>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-validator</artifactId>
 			<version>5.3.5.Final</version>
 		</dependency>
 		<dependency>

--- a/src/main/java/ar/edu/unq/sarmiento/modelo/Carrera.java
+++ b/src/main/java/ar/edu/unq/sarmiento/modelo/Carrera.java
@@ -75,6 +75,13 @@ public class Carrera extends Persistible {
 	}
 	
 	public void agregarMateria(Materia materia){
+		validarMateriaEsNueva(materia);
 		this.listadoMaterias.add(materia);
+	}
+
+	private void validarMateriaEsNueva(Materia materia) {
+		if (this.listadoMaterias.stream().anyMatch(m -> m.getNombre().equals(materia.getNombre()))) {
+			throw new ModelException("Ya existe una materia llamada " + materia.getNombre() + ".");
+		};
 	}
 }

--- a/src/main/java/ar/edu/unq/sarmiento/modelo/Materia.java
+++ b/src/main/java/ar/edu/unq/sarmiento/modelo/Materia.java
@@ -22,6 +22,14 @@ public class Materia extends Persistible {
 	private int anioEnCarrera;
 	private String docente;
 	private boolean esDificil;
+	
+	public Materia() {
+		
+	}
+	
+	public Materia(String nombre) {
+		this.nombre = nombre;
+	}
 
 	public String getNombre() {
 		return nombre;

--- a/src/main/java/ar/edu/unq/sarmiento/modelo/ModelException.java
+++ b/src/main/java/ar/edu/unq/sarmiento/modelo/ModelException.java
@@ -1,0 +1,9 @@
+package ar.edu.unq.sarmiento.modelo;
+
+public class ModelException extends RuntimeException {
+
+	public ModelException(String message) {
+		super(message);
+	}
+
+}

--- a/src/main/java/ar/edu/unq/sarmiento/wicket/crearCarrera/CrearCarreraController.java
+++ b/src/main/java/ar/edu/unq/sarmiento/wicket/crearCarrera/CrearCarreraController.java
@@ -3,7 +3,11 @@ package ar.edu.unq.sarmiento.wicket.crearCarrera;
 import java.io.Serializable;
 
 import javax.transaction.Transactional;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
 
+import org.hibernate.validator.constraints.Range;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
@@ -25,9 +29,11 @@ public class CrearCarreraController implements Serializable {
 	@Autowired
 	private CarreraHome carreraHome;
 	private Carrera carrera;
-	
+	@NotNull
 	private String nombre;
+	@NotNull
 	private String resolucion;
+	@Range(min=1, max=6)
 	private float duracion;
 	
 	public void agregarCarrera() {

--- a/src/main/java/ar/edu/unq/sarmiento/wicket/crearCarrera/CrearCarreraPage.java
+++ b/src/main/java/ar/edu/unq/sarmiento/wicket/crearCarrera/CrearCarreraPage.java
@@ -1,5 +1,6 @@
 package ar.edu.unq.sarmiento.wicket.crearCarrera;
 
+import org.apache.wicket.bean.validation.PropertyValidator;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.markup.html.link.Link;
@@ -48,11 +49,10 @@ public class CrearCarreraPage extends  LayoutPage{
 			}
 
 		});
-
-
-		altaCarrera.add(new TextField<>("nombre", new PropertyModel<>(controller, "nombre")));
-		altaCarrera.add(new TextField<>("resolucion", new PropertyModel<>(controller, "resolucion")));
-		altaCarrera.add(new TextField<>("duracion", new PropertyModel<>(controller, "duracion")));
+		
+		altaCarrera.add(new TextField<>("nombre", new PropertyModel<>(controller, "nombre")).add(new PropertyValidator<>()));
+		altaCarrera.add(new TextField<>("resolucion", new PropertyModel<>(controller, "resolucion")).add(new PropertyValidator<>()));
+		altaCarrera.add(new TextField<>("duracion", new PropertyModel<>(controller, "duracion")).add(new PropertyValidator<>()));
 
 		this.add(altaCarrera);
 

--- a/src/main/java/ar/edu/unq/sarmiento/wicket/home/ModelErrorsRequestCycleListenerHandler.java
+++ b/src/main/java/ar/edu/unq/sarmiento/wicket/home/ModelErrorsRequestCycleListenerHandler.java
@@ -1,0 +1,42 @@
+package ar.edu.unq.sarmiento.wicket.home;
+
+import org.apache.wicket.core.request.handler.IPageRequestHandler;
+import org.apache.wicket.core.request.handler.PageProvider;
+import org.apache.wicket.core.request.handler.RenderPageRequestHandler;
+import org.apache.wicket.markup.html.WebPage;
+import org.apache.wicket.request.IRequestHandler;
+import org.apache.wicket.request.cycle.IRequestCycleListener;
+import org.apache.wicket.request.cycle.PageRequestHandlerTracker;
+import org.apache.wicket.request.cycle.RequestCycle;
+
+import ar.edu.unq.sarmiento.modelo.ModelException;
+
+final class ModelErrorsRequestCycleListenerHandler implements IRequestCycleListener {
+	@Override
+	public IRequestHandler onException(RequestCycle cycle, Exception ex) {
+		if (!esErrorDelModelo(ex)) {
+			return handlerOriginal(cycle);
+		} 
+		
+		try {
+			return mostrarErrorEnFeedbackPanel(cycle, ex);
+		} catch (Exception e) {
+			return handlerOriginal(cycle);
+		}
+	}
+
+	private IRequestHandler handlerOriginal(RequestCycle cycle) {
+		return cycle.getActiveRequestHandler();
+	}
+
+	private boolean esErrorDelModelo(Exception ex) {
+		return ex instanceof ModelException;
+	}
+
+	private IRequestHandler mostrarErrorEnFeedbackPanel(RequestCycle cycle, Exception ex) {
+		IPageRequestHandler last = PageRequestHandlerTracker.getLastHandler(cycle);
+		WebPage page = (WebPage) (last.getPage());
+		page.error(ex.getMessage());
+		return new RenderPageRequestHandler(new PageProvider(page));
+	}
+}

--- a/src/main/java/ar/edu/unq/sarmiento/wicket/home/WicketApplication.java
+++ b/src/main/java/ar/edu/unq/sarmiento/wicket/home/WicketApplication.java
@@ -1,22 +1,46 @@
 package ar.edu.unq.sarmiento.wicket.home;
 
 import org.apache.wicket.Page;
+import org.apache.wicket.core.request.handler.IPageRequestHandler;
+import org.apache.wicket.core.request.handler.PageProvider;
+import org.apache.wicket.core.request.handler.RenderPageRequestHandler;
+import org.apache.wicket.markup.html.WebPage;
 import org.apache.wicket.protocol.http.WebApplication;
+import org.apache.wicket.request.IRequestHandler;
+import org.apache.wicket.request.cycle.IRequestCycleListener;
+import org.apache.wicket.request.cycle.PageRequestHandlerTracker;
+import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.spring.injection.annot.SpringComponentInjector;
 
 import ar.edu.unq.sarmiento.hibernate.HibernateConf;
 import ar.edu.unq.sarmiento.hibernate.HibernateConf.HibernateMode;
+import ar.edu.unq.sarmiento.modelo.ModelException;
 
-public class WicketApplication extends WebApplication{
+public class WicketApplication extends WebApplication {
 
 	@Override
 	public Class<? extends Page> getHomePage() {
 		HibernateConf.modo = HibernateMode.SERVER;
 		return HomePage.class;
 	}
+
 	@Override
 	protected void init() {
 		super.init();
-	    getComponentInstantiationListeners().add(new SpringComponentInjector(this));
+		getComponentInstantiationListeners().add(new SpringComponentInjector(this));
+		getRequestCycleListeners().add(new PageRequestHandlerTracker());
+		getRequestCycleListeners().add(new IRequestCycleListener() {
+			@Override
+			public IRequestHandler onException(RequestCycle cycle, Exception ex) {
+				if (ex instanceof ModelException) {
+					IPageRequestHandler last = PageRequestHandlerTracker.getLastHandler(cycle);
+					WebPage page = (WebPage) (last.getPage());
+					page.error(ex.getMessage());
+					return new RenderPageRequestHandler(new PageProvider(page));
+				} else {
+					return cycle.getActiveRequestHandler();
+				}
+			}
+		});
 	}
 }

--- a/src/main/java/ar/edu/unq/sarmiento/wicket/home/WicketApplication.java
+++ b/src/main/java/ar/edu/unq/sarmiento/wicket/home/WicketApplication.java
@@ -1,23 +1,14 @@
 package ar.edu.unq.sarmiento.wicket.home;
 
 import org.apache.wicket.Page;
-import org.apache.wicket.core.request.handler.IPageRequestHandler;
-import org.apache.wicket.core.request.handler.PageProvider;
-import org.apache.wicket.core.request.handler.RenderPageRequestHandler;
-import org.apache.wicket.markup.html.WebPage;
 import org.apache.wicket.protocol.http.WebApplication;
-import org.apache.wicket.request.IRequestHandler;
-import org.apache.wicket.request.cycle.IRequestCycleListener;
 import org.apache.wicket.request.cycle.PageRequestHandlerTracker;
-import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.spring.injection.annot.SpringComponentInjector;
 
 import ar.edu.unq.sarmiento.hibernate.HibernateConf;
 import ar.edu.unq.sarmiento.hibernate.HibernateConf.HibernateMode;
-import ar.edu.unq.sarmiento.modelo.ModelException;
 
 public class WicketApplication extends WebApplication {
-
 	@Override
 	public Class<? extends Page> getHomePage() {
 		HibernateConf.modo = HibernateMode.SERVER;
@@ -29,18 +20,6 @@ public class WicketApplication extends WebApplication {
 		super.init();
 		getComponentInstantiationListeners().add(new SpringComponentInjector(this));
 		getRequestCycleListeners().add(new PageRequestHandlerTracker());
-		getRequestCycleListeners().add(new IRequestCycleListener() {
-			@Override
-			public IRequestHandler onException(RequestCycle cycle, Exception ex) {
-				if (ex instanceof ModelException) {
-					IPageRequestHandler last = PageRequestHandlerTracker.getLastHandler(cycle);
-					WebPage page = (WebPage) (last.getPage());
-					page.error(ex.getMessage());
-					return new RenderPageRequestHandler(new PageProvider(page));
-				} else {
-					return cycle.getActiveRequestHandler();
-				}
-			}
-		});
+		getRequestCycleListeners().add(new ModelErrorsRequestCycleListenerHandler());
 	}
 }

--- a/src/main/java/ar/edu/unq/sarmiento/wicket/home/WicketApplication.java
+++ b/src/main/java/ar/edu/unq/sarmiento/wicket/home/WicketApplication.java
@@ -1,6 +1,7 @@
 package ar.edu.unq.sarmiento.wicket.home;
 
 import org.apache.wicket.Page;
+import org.apache.wicket.bean.validation.BeanValidationConfiguration;
 import org.apache.wicket.protocol.http.WebApplication;
 import org.apache.wicket.request.cycle.PageRequestHandlerTracker;
 import org.apache.wicket.spring.injection.annot.SpringComponentInjector;
@@ -21,5 +22,6 @@ public class WicketApplication extends WebApplication {
 		getComponentInstantiationListeners().add(new SpringComponentInjector(this));
 		getRequestCycleListeners().add(new PageRequestHandlerTracker());
 		getRequestCycleListeners().add(new ModelErrorsRequestCycleListenerHandler());
+		new BeanValidationConfiguration().configure(this);
 	}
 }

--- a/src/main/java/ar/edu/unq/sarmiento/wicket/layout/LayoutPage.html
+++ b/src/main/java/ar/edu/unq/sarmiento/wicket/layout/LayoutPage.html
@@ -31,6 +31,7 @@
 					</div>			
 				</nav>
 			</div>
+			<div wicket:id="feedback"></div>
 			<wicket:child />
 		</div>
 		

--- a/src/main/java/ar/edu/unq/sarmiento/wicket/layout/LayoutPage.html
+++ b/src/main/java/ar/edu/unq/sarmiento/wicket/layout/LayoutPage.html
@@ -31,7 +31,9 @@
 					</div>			
 				</nav>
 			</div>
-			<div wicket:id="feedback"></div>
+			<div class="row">
+				<div wicket:id="feedback"></div>
+			</div>
 			<wicket:child />
 		</div>
 		

--- a/src/main/java/ar/edu/unq/sarmiento/wicket/layout/LayoutPage.java
+++ b/src/main/java/ar/edu/unq/sarmiento/wicket/layout/LayoutPage.java
@@ -4,6 +4,7 @@ import org.apache.wicket.Page;
 import org.apache.wicket.markup.html.WebPage;
 import org.apache.wicket.markup.html.image.Image;
 import org.apache.wicket.markup.html.link.Link;
+import org.apache.wicket.markup.html.panel.FeedbackPanel;
 import org.apache.wicket.request.resource.PackageResourceReference;
 
 import ar.edu.unq.sarmiento.wicket.alumno.ListadoAlumnoPage;
@@ -15,6 +16,8 @@ public abstract class LayoutPage extends WebPage {
 		this.agregarLink("homePage", HomePage.class);
 		this.agregarLink("alumnosPage", ListadoAlumnoPage.class);
 		this.agregarLink("carrerasPage", ListadoDeCarrerasPage.class);
+		
+		add(new FeedbackPanel("feedback"));
 	}
 	
 	private void agregarLink(String nombre, Class<? extends Page> pageClass) {

--- a/src/main/java/ar/edu/unq/sarmiento/wicket/layout/LayoutPage.java
+++ b/src/main/java/ar/edu/unq/sarmiento/wicket/layout/LayoutPage.java
@@ -2,14 +2,12 @@ package ar.edu.unq.sarmiento.wicket.layout;
 
 import org.apache.wicket.Page;
 import org.apache.wicket.markup.html.WebPage;
-import org.apache.wicket.markup.html.image.Image;
 import org.apache.wicket.markup.html.link.Link;
-import org.apache.wicket.markup.html.panel.FeedbackPanel;
-import org.apache.wicket.request.resource.PackageResourceReference;
 
 import ar.edu.unq.sarmiento.wicket.alumno.ListadoAlumnoPage;
 import ar.edu.unq.sarmiento.wicket.carrera.ListadoDeCarrerasPage;
 import ar.edu.unq.sarmiento.wicket.home.HomePage;
+import ar.edu.unq.sarmiento.wicket.utils.BootstrapFeedbackPanel;
 
 public abstract class LayoutPage extends WebPage {
 	public LayoutPage() {
@@ -17,7 +15,7 @@ public abstract class LayoutPage extends WebPage {
 		this.agregarLink("alumnosPage", ListadoAlumnoPage.class);
 		this.agregarLink("carrerasPage", ListadoDeCarrerasPage.class);
 		
-		add(new FeedbackPanel("feedback"));
+		add(new BootstrapFeedbackPanel("feedback"));
 	}
 	
 	private void agregarLink(String nombre, Class<? extends Page> pageClass) {

--- a/src/main/java/ar/edu/unq/sarmiento/wicket/utils/BootstrapFeedbackPanel.html
+++ b/src/main/java/ar/edu/unq/sarmiento/wicket/utils/BootstrapFeedbackPanel.html
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<html xmlns:wicket="http://wicket.apache.org">
+<body>
+<wicket:panel>
+  <ul wicket:id="feedbackul" class="feedbackPanel">
+    <li wicket:id="messages">
+      <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+      </button>    
+      <span wicket:id="message">A message</span>
+    </li>
+  </ul>
+</wicket:panel>
+</body>
+</html>

--- a/src/main/java/ar/edu/unq/sarmiento/wicket/utils/BootstrapFeedbackPanel.java
+++ b/src/main/java/ar/edu/unq/sarmiento/wicket/utils/BootstrapFeedbackPanel.java
@@ -16,22 +16,20 @@ public class BootstrapFeedbackPanel extends FeedbackPanel {
 
     @Override
     protected String getCSSClass(FeedbackMessage message) {
-        String css;
+        String css = "alert alert-dismissible";
         switch (message.getLevel()){
             case FeedbackMessage.SUCCESS:
-                css = "alert alert-success";
+                css += " alert-success";
                 break;
             case FeedbackMessage.INFO:
-                css = "alert alert-info";
+                css += " alert-info";
                 break;
             case FeedbackMessage.ERROR:
-                css = "alert alert-danger";
+                css += " alert-danger";
                 break;
             case FeedbackMessage.WARNING:
-                css = "alert alert-warning";
+                css += " alert-warning";
                 break;
-            default:
-                css = "alert";
         }
 
         return css;

--- a/src/main/java/ar/edu/unq/sarmiento/wicket/utils/BootstrapFeedbackPanel.java
+++ b/src/main/java/ar/edu/unq/sarmiento/wicket/utils/BootstrapFeedbackPanel.java
@@ -1,0 +1,39 @@
+package ar.edu.unq.sarmiento.wicket.utils;
+
+import org.apache.wicket.feedback.FeedbackMessage;
+import org.apache.wicket.feedback.IFeedbackMessageFilter;
+import org.apache.wicket.markup.html.panel.FeedbackPanel;
+
+public class BootstrapFeedbackPanel extends FeedbackPanel {
+
+    public BootstrapFeedbackPanel(String id) {
+        super(id);
+    }
+
+    public BootstrapFeedbackPanel(String id, IFeedbackMessageFilter filter) {
+        super(id, filter);
+    }
+
+    @Override
+    protected String getCSSClass(FeedbackMessage message) {
+        String css;
+        switch (message.getLevel()){
+            case FeedbackMessage.SUCCESS:
+                css = "alert alert-success";
+                break;
+            case FeedbackMessage.INFO:
+                css = "alert alert-info";
+                break;
+            case FeedbackMessage.ERROR:
+                css = "alert alert-danger";
+                break;
+            case FeedbackMessage.WARNING:
+                css = "alert alert-warning";
+                break;
+            default:
+                css = "alert";
+        }
+
+        return css;
+    }
+}

--- a/src/main/webapp/css/main.css
+++ b/src/main/webapp/css/main.css
@@ -18,3 +18,9 @@ body {
 .titulo {
 	text-align: center;
 }
+
+.feedbackPanel {
+	list-style-type: none;
+	margin: 0;
+	padding: 0;
+}

--- a/src/test/java/ar/edu/unq/sarmiento/modelo/CarreraTest.java
+++ b/src/test/java/ar/edu/unq/sarmiento/modelo/CarreraTest.java
@@ -1,0 +1,29 @@
+package ar.edu.unq.sarmiento.modelo;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class CarreraTest {
+	private Carrera tpi;
+	
+	@Before
+	public void setUp() {
+		tpi = new Carrera();
+	}
+
+	@Test(expected=ModelException.class)
+	public void noSePuedenAgregarDosMateriasConElMismoNombre() {
+		tpi.agregarMateria(new Materia("Introducción a la programación"));
+		tpi.agregarMateria(new Materia("Introducción a la programación"));
+	}
+	
+	@Test
+	public void sePuedenAgregarMateriasConNombresDistintos() {
+		tpi.agregarMateria(new Materia("Introducción a la programación"));
+		tpi.agregarMateria(new Materia("Estructuras de datos"));
+		
+		assertEquals(2, tpi.getListadoMaterias().size());
+	}
+}


### PR DESCRIPTION
Closes #138 

Incorporé un mecanismo para manejar errores de forma transparente, que se ve así:

![image](https://user-images.githubusercontent.com/1585835/55252512-e0ce4380-5231-11e9-91ca-46ef0f33d920.png)

![image](https://user-images.githubusercontent.com/1585835/55252882-a022fa00-5232-11e9-8f44-f5f91bef4df3.png)

Hay dos formas de hacer que tire error, dejé un ejemplo de cada una:
1. Agregando annotations a los campos, para hacer validaciones de input. Ojo que esto hay que hacerlo en el modelo que usa Wicket (la mayoría de las veces, un controller). Pueden ver en http://docs.jboss.org/hibernate/stable/validator/reference/en-US/html_single/#section-builtin-constraints las annotations que existen.
1. Tirando una `ModelException` en algún método. Esto es útil para validaciones que tienen que ver con la lógica de negocio y no con el input del usuario.